### PR TITLE
wait for mofed driver installation after the cleanup driver call

### DIFF
--- a/driver-manager
+++ b/driver-manager
@@ -571,12 +571,6 @@ _wait_for_mofed_driver() {
 }
 
 uninstall_driver() {
-    # when GPUDirectRDMA is enabled, wait until MOFED driver has finished installing
-    if _gpu_direct_rdma_enabled; then
-        echo "GPUDirectRDMA is enabled, validating MOFED driver installation"
-        _wait_for_mofed_driver
-    fi
-
     # don't attempt to un-install if driver is pre-installed on the node
     if _host_driver; then
         echo "NVIDIA GPU driver is already pre-installed on the node, disabling the containerized driver on the node"
@@ -643,6 +637,12 @@ uninstall_driver() {
     if [ "$?" != "0" ]; then
         echo "Unable to unbind vfio-pci driver from all devices"
         _exit_failed
+    fi
+
+    # when GPUDirectRDMA is enabled, wait until MOFED driver has finished installing
+    if _gpu_direct_rdma_enabled; then
+        echo "GPUDirectRDMA is enabled, validating MOFED driver installation"
+        _wait_for_mofed_driver
     fi
 
     if _is_gpu_pod_eviction_enabled || _is_auto_drain_enabled; then


### PR DESCRIPTION
To resolve the deadlock from circular dependency between the mofed and gpu driver containers, we switch the order of unloading gpu driver modules and waiting for the mofed driver install. This way, we ensure that an existing nvidia_peermem module would not get in the way of the MOFED installation in a cluster