### PR TITLE
run go build in the cuda base image rather golang

### DIFF
--- a/deployments/container/Dockerfile.ubi8
+++ b/deployments/container/Dockerfile.ubi8
@@ -14,9 +14,8 @@
 
 ARG CUDA_VERSION
 ARG BASE_DIST
-ARG GOLANG_VERSION=x.x.x
 
-FROM golang:${GOLANG_VERSION} AS build
+FROM nvcr.io/nvidia/cuda:${CUDA_VERSION}-base-${BASE_DIST} AS build
 
 WORKDIR /work
 
@@ -25,9 +24,27 @@ COPY go.sum go.sum
 COPY vendor vendor
 COPY cmd/nvdrain cmd/nvdrain
 
+RUN dnf install -y wget make git gcc
+
+ARG GOLANG_VERSION=0.0.0
+RUN set -eux; \
+    \
+    arch="$(uname -m)"; \
+    case "${arch##*-}" in \
+        x86_64 | amd64) ARCH='amd64' ;; \
+        ppc64el | ppc64le) ARCH='ppc64le' ;; \
+        aarch64 | arm64) ARCH='arm64' ;; \
+        *) echo "unsupported architecture" ; exit 1 ;; \
+    esac; \
+    wget -nv -O - https://storage.googleapis.com/golang/go${GOLANG_VERSION}.linux-${ARCH}.tar.gz \
+    | tar -C /usr/local -xz
+
+ENV GOPATH /go
+ENV PATH $GOPATH/bin:/usr/local/go/bin:$PATH
+
 RUN GOOS=linux go build -o nvdrain ./cmd/nvdrain
 
-FROM nvidia/cuda:${CUDA_VERSION}-base-${BASE_DIST}
+FROM nvcr.io/nvidia/cuda:${CUDA_VERSION}-base-${BASE_DIST}
 
 ARG TARGETARCH
 


### PR DESCRIPTION
This change gets around the following error:

```
Auto upgrade policy of the GPU driver on the node cnt-server-2 is disabled
Cordoning node cnt-server-2...
node/cnt-server-2 cordoned
Draining node cnt-server-2 of any GPU pods...
nvdrain: /lib64/libc.so.6: version `GLIBC_2.34' not found (required by nvdrain)
nvdrain: /lib64/libc.so.6: version `GLIBC_2.32' not found (required by nvdrain)
```

By running the `go build` in the runtime environment (cuda-base image), we remove the possibility of any execution failure from the glibc mismatch