### PR TITLE
enable bumping k8s.io deps via dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,10 +9,14 @@ updates:
     schedule:
       interval: "weekly"
       day: "sunday"
-    ignore:
-    - dependency-name: k8s.io/*
     labels:
     - dependencies
+    groups:
+      k8sio:
+        patterns:
+          - k8s.io/*
+        exclude-patterns:
+          - k8s.io/klog/*
 
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
Following this [example](https://github.com/NVIDIA/k8s-device-plugin/blob/main/.github/dependabot.yml)