### PR TITLE
use latest stable version of docker:dind for gitlab CI

### DIFF
--- a/.common-ci.yml
+++ b/.common-ci.yml
@@ -13,9 +13,9 @@
 # limitations under the License.
 
 default:
-  image: docker:stable
+  image: docker:dind
   services:
-    - name: docker:stable-dind
+    - name: docker:dind
       command: ["--experimental"]
 
 variables:


### PR DESCRIPTION
This fixes the docker runtime issue observed in our gitlab CI pipelines.

https://github.com/docker/for-linux/issues/219