### PR TITLE
fix govet issues reported in latest golangci-lint versions

### DIFF
--- a/cmd/nvdrain/main.go
+++ b/cmd/nvdrain/main.go
@@ -137,7 +137,7 @@ func main() {
 
 	err := c.Run(os.Args)
 	if err != nil {
-		log.Fatalf(err.Error())
+		log.Fatal(err.Error())
 	}
 }
 


### PR DESCRIPTION
Fixes the following issue

```
run golangci-lint
  Running [/home/runner/golangci-lint-1.60.3-linux-amd64/golangci-lint run  -v --timeout 5m] in [/home/runner/work/k8s-driver-manager/k8s-driver-manager] ...
  cmd/nvdrain/main.go:140:14: printf: non-constant format string in call to (*github.com/sirupsen/logrus.Logger).Fatalf (govet)
  		log.Fatalf(err.Error())
  		           ^
```