### PR TITLE
Add Error check for Node Label Failure

### DIFF
--- a/cmd/driver-manager/main.go
+++ b/cmd/driver-manager/main.go
@@ -395,7 +395,7 @@ func (dm *DriverManager) uninstallDriver() error {
 	}
 
 	if err := dm.rescheduleGPUOperatorComponents(); err != nil {
-		dm.log.Warnf("Failed to reschedule GPU operator components: %v", err)
+		return fmt.Errorf("failed to reschedule GPU operator components: %w", err)
 	}
 
 	// Handle nouveau driver


### PR DESCRIPTION
This MR is related to this issue https://github.com/NVIDIA/k8s-driver-manager/issues/118. The goal is to ensure that when the k8s-driver-manager attempts to reschedule the GPU Operator operands, if it fails, we treat this as a fatal error. That way we wouldn't be in a state where the driver manager is ready but the other operands have not come up.

In a previous [MR](https://github.com/NVIDIA/k8s-driver-manager/pull/139) where this was discussed, we added logic to retry the updateNodeLabels() operations in case it ran into errors. That way the k8s-driver-manager will attempt to reschedule the operands to run if the initial operation fails. This MR ensures that if it continues to error after several retries, we treat this as fatal as discussed in the issue rather than just have a warning.