### PR TITLE
Skip vfio-pci unbind when GPUs already bound in VFIO mode

### DIFF
--- a/cmd/driver-manager/main.go
+++ b/cmd/driver-manager/main.go
@@ -796,9 +796,13 @@ func (dm *DriverManager) unmountRootfs() error {
 }
 
 // If vfio-pci driver is in use, ensure we unbind it from all devices.
-// If vfio-pci driver is not in use, and we have reached this point, all devices will not be bound to any driver,
-// so the below unbind operation will be a no-op.
+// In VFIO workload mode (vm-passthrough), skip unneccsary unbind.
 func (dm *DriverManager) unbindVfioPCI() error {
+	if dm.isVFIOWorkloadConfig() {
+		dm.log.Info("VFIO workload mode, skipping vfio-pci unbind")
+		return nil
+	}
+
 	dm.log.Info("Unbinding vfio-pci driver from all devices")
 	cmd := exec.Command("vfio-manage", "unbind", "--all")
 	return cmd.Run()
@@ -952,4 +956,9 @@ func (dm *DriverManager) cleanupOnFailure() {
 	if err := dm.rescheduleGPUOperatorComponents(); err != nil {
 		dm.log.Warnf("Failed to reschedule GPU operator components during cleanup: %v", err)
 	}
+}
+
+func (dm *DriverManager) isVFIOWorkloadConfig() bool {
+	workloadConfig := os.Getenv("GPU_WORKLOAD_CONFIG")
+	return workloadConfig == "vm-passthrough"
 }


### PR DESCRIPTION
Relevant PR: https://github.com/NVIDIA/gpu-operator/pull/2079

## Description

Prevents unnecessary GPU unbind/rebind operations during rolling updates of the vfio-manager DaemonSet. Currently, k8s-driver-manager unconditionally unbinds all GPUs from vfio-pci on startup, even when the desired state is already vfio-pci. This disrupts active VM workloads using GPU passthrough (KubeVirt, Kata Containers).

### Solution

Check for `GPU_WORKLOAD_CONFIG` environment variable to determine if the pod is running in VFIO workload mode. When set to `vm-passthrough`, skip the vfio-pci unbind operation since GPUs should remain bound to vfio-pci.

### Behavior by DaemonSet Context

| DaemonSet | `GPU_WORKLOAD_CONFIG` | Unbind vfio-pci? | Reason |
|-----------|----------------------|------------------|--------|
| nvidia-driver | _(not set)_ | Yes | Prepares GPUs for NVIDIA kernel driver |
| vfio-manager | `vm-passthrough` |  No | GPUs should remain bound to vfio-pci |
| vgpu-manager | _(not set)_ | Yes | Prepares GPUs for vGPU manager |