### PR TITLE
add workflow to mark issues as stale

### DIFF
--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -1,0 +1,25 @@
+name: Stale issues
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "21 4 * * *"
+
+jobs:
+  stale:
+    permissions:
+      actions: write
+      issues: write
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/stale@v10
+        with:
+          stale-issue-message: 'This issue is stale because it has been open 90 days with no activity. This issue will be closed in 30 days unless new comments are made or the stale label is removed. To skip these checks, apply the "feature, enhancement or lifecycle/frozen" labels.'
+          stale-issue-label: 'lifecycle/stale'
+          exempt-issue-labels: 'lifecycle/frozen,feature,enhancement'
+          days-before-stale: 90
+          close-issue-message: 'This issue was automatically closed due to inactivity.'
+          days-before-issue-close: 30
+          remove-stale-when-updated: true
+          operations-per-run: 300


### PR DESCRIPTION
This PR adds workflow which runs periodically and labels issues as stale if there is no activity for pre-defined time.