### PR TITLE
Add cleanup guidance in case driver pod is stuck uninstalling the driver

### DIFF
--- a/cmd/driver-manager/main.go
+++ b/cmd/driver-manager/main.go
@@ -906,7 +906,7 @@ func (dm *DriverManager) maybeSetTrue(currentValue string) string {
 
 func (dm *DriverManager) isAutoDrainEnabled() bool {
 	if dm.isDriverAutoUpgradePolicyEnabled() {
-		dm.log.Info("Auto drain of the node is disabled by the upgrade policy")
+		dm.log.Info(autoDrainSupersededByPolicyMsg)
 		return false
 	}
 	return dm.config.enableAutoDrain
@@ -914,7 +914,7 @@ func (dm *DriverManager) isAutoDrainEnabled() bool {
 
 func (dm *DriverManager) isGPUPodEvictionEnabled() bool {
 	if dm.isDriverAutoUpgradePolicyEnabled() {
-		dm.log.Infof("Auto eviction of GPU pods on node %s is disabled by the upgrade policy", dm.config.nodeName)
+		dm.log.Info(gpuPodEvictionSupersededByPolicyMsg)
 		return false
 	}
 	return dm.config.enableGPUPodEviction
@@ -942,11 +942,18 @@ func (dm *DriverManager) isDriverAutoUpgradePolicyEnabled() bool {
 
 func (dm *DriverManager) cleanupOnFailure() {
 	dm.log.Info("Performing cleanup on failure")
+	policyEnabled := dm.isDriverAutoUpgradePolicyEnabled()
+	managerCanEvict := !policyEnabled && (dm.config.enableGPUPodEviction || dm.config.enableAutoDrain)
 
-	if dm.isGPUPodEvictionEnabled() || dm.isAutoDrainEnabled() {
+	switch {
+	case managerCanEvict:
 		if err := dm.kubeClient.UncordonNode(dm.config.nodeName); err != nil {
 			dm.log.Warnf("Failed to uncordon node during cleanup: %v", err)
 		}
+	case policyEnabled:
+		dm.log.Warnf(cleanupGuidancePolicyEnabledMsg, dm.config.nodeName, dm.config.nodeName)
+	default:
+		dm.log.Warnf(cleanupGuidanceFeaturesDisabledMsg, dm.config.nodeName)
 	}
 
 	if err := dm.rescheduleGPUOperatorComponents(); err != nil {

--- a/cmd/driver-manager/messages.go
+++ b/cmd/driver-manager/messages.go
@@ -1,0 +1,46 @@
+//go:build !darwin && !windows
+
+/*
+ * Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package main
+
+const (
+	autoDrainSupersededByPolicyMsg      = "Auto drain by driver-manager has been superseded by the GPU Operator's upgrade policy. The GPU Operator will perform the GPU node drain instead"
+	gpuPodEvictionSupersededByPolicyMsg = "GPU pod eviction by driver-manager has been superseded by the GPU Operator's upgrade policy. The GPU Operator will perform the workload eviction instead"
+
+	cleanupGuidancePolicyEnabledMsg = `Cleanup could not automatically proceed on node %s because the GPU driver auto-upgrade policy is enabled and upgrade-controller manages GPU workload eviction.
+
+Note: reconciliation is automatic; after any option below is applied, the system will retry without manual intervention.
+
+Cleanup guidance (choose one):
+	[1] Manually stop workloads using GPUs on this node so that the GPUs are released.
+	[2] Disable the GPU driver auto-upgrade policy in the GPU Operator ClusterPolicy and ensure k8s-driver-manager has ENABLE_GPU_POD_EVICTION=true (and optionally ENABLE_AUTO_DRAIN=true) so driver-manager can auto-evict GPU workloads.
+	[3] Request upgrade-controller to auto-evict GPU workloads for this node now by running:
+			kubectl label node %s nvidia.com/gpu-driver-upgrade-state=upgrade-required --overwrite
+	[4] Wait for running GPU workloads to finish and release GPUs on this node.
+`
+
+	cleanupGuidanceFeaturesDisabledMsg = `Cleanup could not automatically proceed on node %s because both GPU pod eviction and auto-drain are disabled.
+
+Note: reconciliation is automatic; after any option below is applied, the system will retry without manual intervention.
+
+Cleanup guidance (choose one):
+	[1] Enable driver-manager eviction settings: set ENABLE_GPU_POD_EVICTION=true and/or ENABLE_AUTO_DRAIN=true.
+	[2] Manually stop GPU workloads on this node so that the GPUs are released.
+	[3] Wait for running GPU workloads to finish and release GPUs on this node.
+`
+)


### PR DESCRIPTION
Note: Once v26.3.0 is released and we support not reinstalling driver on container restarts, we might not hit this issue as often as we do as of today.

In worst case if we ever hit this issue where k8s-driver-manager tries to uninstall the driver without upgrade-controller requesting it to do so safely, these detailed log messages will help users recover from such situations.

This change adds better logging on how to recover in case driver pod is stuck trying to uninstall driver and there are workloads using GPU.

Without the change:
```
time=2026-03-06T20:37:58Z level=info msg=Auto drain of the node is disabled by the upgrade policy
time=2026-03-06T20:37:58Z level=error msg=Failed to uninstall nvidia driver components
time=2026-03-06T20:37:58Z level=info msg=Performing cleanup on failure
time=2026-03-06T20:37:58Z level=info msg=Auto eviction of GPU pods on node ipp2-2153 is disabled by the upgrade policy
time=2026-03-06T20:37:58Z level=info msg=Auto drain of the node is disabled by the upgrade policy
time=2026-03-06T20:37:58Z level=info msg=Rescheduling all GPU clients on the current node by enabling their component-specific nodeSelector labels
time=2026-03-06T20:37:58Z level=fatal msg=failed to uninstall nvidia driver components: failed to unload driver: resource temporarily unavailable
```

With this change and driver pod failing to uninstall driver due to a workload using GPU:
```
time=2026-03-06T20:13:24Z level=info msg=Auto drain by driver-manager is skipped because the ClusterPolicy has the GPU driver auto-upgrade enabled and upgrade-controller manages GPU workload eviction
time=2026-03-06T20:13:24Z level=error msg=Failed to uninstall nvidia driver components
time=2026-03-06T20:13:24Z level=info msg=Performing cleanup on failure
time=2026-03-06T20:13:24Z level=warning msg=Cleanup could not automatically proceed on node ipp2-2153 because the GPU driver auto-upgrade policy is enabled and upgrade-controller manages GPU workload eviction.

Note: reconciliation is automatic; after any option below is applied, the system will retry without manual intervention.

Cleanup guidance (choose one):
  [1] Manually stop workloads using GPUs on this node so that the GPUs are released.
  [2] Disable the GPU driver auto-upgrade policy in the GPU Operator ClusterPolicy and ensure k8s-driver-manager has ENABLE_GPU_POD_EVICTION=true (and optionally ENABLE_AUTO_DRAIN=true) so driver-manager can auto-evict GPU workloads.
  [3] Request upgrade-controller to auto-evict GPU workloads for this node now by running:
      kubectl label node ipp2-2153 nvidia.com/gpu-driver-upgrade-state=upgrade-required --overwrite
  [4] Wait for running GPU workloads to finish and release GPUs on this node.

time=2026-03-06T20:13:24Z level=info msg=Rescheduling all GPU clients on the current node by enabling their component-specific nodeSelector labels
time=2026-03-06T20:13:24Z level=fatal msg=failed to uninstall nvidia driver components: failed to unload driver: resource temporarily unavailable
```