### PR TITLE
retry with longer exponential retry wait, error out in case of failure

### DIFF
--- a/cmd/driver-manager/main.go
+++ b/cmd/driver-manager/main.go
@@ -312,7 +312,7 @@ func (dm *DriverManager) uninstallDriver() error {
 		dm.removePIDFile()
 
 		if err := dm.rescheduleGPUOperatorComponents(); err != nil {
-			dm.log.Warnf("Failed to reschedule GPU operator components: %v", err)
+			return fmt.Errorf("failed to reschedule GPU operator components: %w", err)
 		}
 		return nil
 	}

--- a/internal/kubernetes/client.go
+++ b/internal/kubernetes/client.go
@@ -108,7 +108,14 @@ func (c *Client) UpdateNodeLabels(nodeName string, nodeLabels map[string]string)
 		return fmt.Errorf("failed to marshal patch: %w", err)
 	}
 
-	return retry.OnError(retry.DefaultBackoff, func(err error) bool {
+	backoff := wait.Backoff{
+		Duration: time.Second,
+		Factor:   2.0,
+		Jitter:   0.2,
+		Steps:    7,
+	}
+
+	return retry.OnError(backoff, func(err error) bool {
 		return true
 	}, func() error {
 		_, err := c.clientset.CoreV1().Nodes().Patch(c.ctx, nodeName, types.StrategicMergePatchType, patchBytes, metav1.PatchOptions{})


### PR DESCRIPTION
## Problem

We have seen issues where on apiserver connectivity blips, k8s-driver-manager fails to update labels. Example:
```
time=2026-03-30T09:02:26Z level=info    msg="Auto eviction of GPU pods on node master0 is disabled by the upgrade policy"
time=2026-03-30T09:02:26Z level=info    msg="Auto drain of the node is disabled by the upgrade policy"
time=2026-03-30T09:02:26Z level=info    msg="Rescheduling all GPU clients on the current node by enabling their component-specific nodeSelector labels"
time=2026-03-30T09:02:26Z level=warning msg="Failed to update labels on node master0, retrying: Patch \"https://172.22.0.1:443/api/v1/nodes/master0\": dial tcp 172.22.0.1:443: connect: connection refused"
time=2026-03-30T09:02:26Z level=warning msg="Failed to update labels on node master0, retrying: Patch \"https://172.22.0.1:443/api/v1/nodes/master0\": dial tcp 172.22.0.1:443: connect: connection refused"
time=2026-03-30T09:02:26Z level=warning msg="Failed to update labels on node master0, retrying: Patch \"https://172.22.0.1:443/api/v1/nodes/master0\": dial tcp 172.22.0.1:443: connect: connection refused"
time=2026-03-30T09:02:26Z level=warning msg="Failed to update labels on node master0, retrying: Patch \"https://172.22.0.1:443/api/v1/nodes/master0\": dial tcp 172.22.0.1:443: connect: connection refused"
time=2026-03-30T09:02:26Z level=warning msg="Failed to reschedule GPU operator components: Patch \"https://172.22.0.1:443/api/v1/nodes/master0\": dial tcp 172.22.0.1:443: connect: connection refused"
time=2026-03-30T09:02:26Z level=info    msg="Driver uninstallation completed successfully"

```

This results in stale/incorrect labels left on nodes and gpu-operator fails to move the cluster to desired state.

For example, some nodes were left with labels with values `paused-for-driver-upgrade` and never recovered from it.

## Changes in this PR

### Use a longer exponential retry

Currently, we use retry.DefaultBackoff https://pkg.go.dev/k8s.io/client-go/util/retry#pkg-variables which is:
```
var DefaultBackoff = wait.Backoff{
	Steps:    4,
	Duration: 10 * time.MilliSecond,
	Factor:   5.0,
	Jitter:   0.1,
}
```
If all backoff intervals are consumed, sleep sequence is roughly (ignoring jitter which is random(0, interval * jitter)):
10ms, 10 * 5ms, 10 * 5 * 5ms, 10 * 5 * 5 * 5ms

So, the total sleep when all retries are exhausted is: 10ms + 50ms + 250ms + 1250ms = roughly 1600ms = roughly 1.6 secs with jitter.

For scenarios like apiserver blips, we need a longer retry interval.

With this change, I am proposing:
```
	backoff := wait.Backoff{
		Duration: time.Second,
		Factor:   2.0,
		Jitter:   0.2,
		Steps:    7,
	}
```
If all backoff intervals are consumed, sleep sequence is roughly (ignoring jitter which is random(0, interval * jitter)):
1s, 2s, 4s, 8s, 16s, 32s, 64s

So, the total sleep when all retries are exhausted is around 130 secs or so. This gives enough time for apiserver recovery in case there are blips etc.

### Consider k8s API errors as hard/fatal errors
A similar change was done in https://github.com/NVIDIA/k8s-driver-manager/pull/141 and merged recently.
In this PR, I am adding the fix during `dm.shouldSkipUninstall()` check as well which was missed.