### PR TITLE
Ship static busybox shell in k8s-driver-manager image

### DIFF
--- a/deployments/container/Dockerfile.distroless
+++ b/deployments/container/Dockerfile.distroless
@@ -55,12 +55,24 @@ RUN go build -ldflags "-extldflags=-Wl,-z,lazy -s -w -X ${VERSION_PKG}.gitCommit
 
 ARG TARGETARCH
 
-FROM nvcr.io/nvidia/distroless/cc:v4.0.6-dev
+# Build a static busybox layout: one binary plus applet symlinks (sh, rm,
+# ln, sleep, cat, ...) so PATH-resolved commands in init-container wrappers
+# and lifecycle hooks keep working on the non-*-dev* distroless base.
+FROM debian:trixie-slim AS shell
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends busybox-static \
+ && rm -rf /var/lib/apt/lists/* \
+ && mkdir /busybox \
+ && cp /bin/busybox /busybox/busybox \
+ && /busybox/busybox --install -s /busybox
+
+FROM nvcr.io/nvidia/distroless/cc:v4.0.6
 
 USER 0:0
 
-SHELL ["/busybox/sh", "-c"]
-RUN ln -s /busybox/sh /bin/sh
+COPY --from=shell /busybox /busybox
+RUN ["/busybox/ln", "-s", "/busybox/sh", "/bin/sh"]
+ENV PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/busybox
 
 COPY --from=build /work/vfio-manage /usr/bin
 COPY --from=build /work/driver-manager /usr/bin


### PR DESCRIPTION
Flip the base from `*-dev*` to non-`*-dev*` distroless and source a static busybox from `debian:trixie-slim`. The driver-manager preflight and upgrade workflows continue to work via `/bin/sh` and busybox applet symlinks layered into the final image.

Part of NVIDIA/cloud-native-team#299.
Resolves #179.