### PR TITLE
Drain the DRA kubelet-plugin and validator across driver reloads

### DIFF
--- a/cmd/driver-manager/main.go
+++ b/cmd/driver-manager/main.go
@@ -63,6 +63,8 @@ const (
 	nvidiaSandboxDevicePluginDeployLabel = nvidiaDomainPrefix + "/" + "gpu.deploy.sandbox-device-plugin"
 	nvidiaVGPUDeviceManagerDeployLabel   = nvidiaDomainPrefix + "/" + "gpu.deploy.vgpu-device-manager"
 	nvidiaGPUClientDeployLabel           = nvidiaDomainPrefix + "/" + "gpu.deploy.client"
+	nvidiaDRADriverDeployLabel           = nvidiaDomainPrefix + "/" + "gpu.deploy.dra-driver"
+	nvidiaDRAValidatorDeployLabel        = nvidiaDomainPrefix + "/" + "gpu.deploy.dra-validator"
 )
 
 // Configuration holds all the configuration from environment variables
@@ -95,6 +97,8 @@ type componentState struct {
 	sandboxValidatorDeployed    string
 	sandboxPluginDeployed       string
 	vgpuDeviceManagerDeployed   string
+	draDriverDeployed           string
+	draValidatorDeployed        string
 	customOperandNodeLabelValue string
 	gpuClientsDeployed          string
 	autoUpgradePolicyEnabled    string
@@ -292,7 +296,10 @@ func (dm *DriverManager) uninstallDriver() error {
 		return fmt.Errorf("failed to fetch auto upgrade annotation: %w", err)
 	}
 
-	// Always evict all GPU operator components across a driver restart
+	// Always evict all GPU operator components across a driver restart. The DRA
+	// kubelet-plugin is the exception: it services NodeUnprepareResources for the
+	// claim-holders evicted here (e.g. dra-validator), so it must outlive them and
+	// is drained separately afterwards (see evictKubeletPlugin).
 	if err := dm.evictAllGPUOperatorComponents(); err != nil {
 		dm.log.Error("Failed to evict GPU operator components, attempting cleanup")
 		dm.cleanupOnFailure()
@@ -301,6 +308,17 @@ func (dm *DriverManager) uninstallDriver() error {
 
 	if dm.shouldSkipUninstall() {
 		dm.log.Info("The NVIDIA driver is already loaded with the desired version and configuration, skipping the uninstallation of the driver in an attempt to not disrupt running workloads")
+
+		// The DRA kubelet-plugin bind-mounts the previous driver container's rootfs.
+		// That bind does not track the host mount point, so the replacement driver
+		// container's rootfs never appears inside the running plugin and, once the
+		// stale rootfs is unmounted below, its submounts (e.g. dev/) vanish from the
+		// plugin's view, leaving NodePrepareResources unable to build CDI specs.
+		// Restart the plugin across the rotation so it re-binds the new rootfs.
+		if err := dm.evictKubeletPlugin(); err != nil {
+			dm.cleanupOnFailure()
+			return fmt.Errorf("failed to evict DRA kubelet-plugin: %w", err)
+		}
 
 		// Clean up stale artifacts from previous container before rescheduling operands
 		dm.log.Info("Cleaning up stale mounts and state files...")
@@ -326,8 +344,10 @@ func (dm *DriverManager) uninstallDriver() error {
 		PodSelector:        dm.config.drainPodSelectorLabel,
 	}
 
-	// Delete any GPU pods running on the node
-	if dm.isGPUPodEvictionEnabled() {
+	// Delete any GPU pods running on the node. With DRA, evict GPU pods up front:
+	// the post-unload auto-drain fallback runs after the kubelet-plugin is gone,
+	// leaving drained claim-holders stuck in Terminating.
+	if dm.isGPUPodEvictionEnabled() || (dm.components.draDriverDeployed != "" && dm.isAutoDrainEnabled()) {
 		if err := dm.kubeClient.CordonNode(dm.config.nodeName); err != nil {
 			return fmt.Errorf("failed to cordon node: %w", err)
 		}
@@ -343,11 +363,30 @@ func (dm *DriverManager) uninstallDriver() error {
 				dm.cleanupOnFailure()
 				return fmt.Errorf("failed to drain node: %w", err)
 			}
-			if err := dm.cleanupDriver(); err != nil {
-				dm.cleanupOnFailure()
-				return fmt.Errorf("failed to cleanup NVIDIA driver: %w", err)
-			}
 		}
+	}
+
+	// The eviction above and the auto-drain fallback below are both disabled when the GPU
+	// Operator's upgrade policy owns the drain, so confirm the claim-holders are gone
+	// rather than assuming it: without the plugin they cannot finish terminating.
+	if dm.components.draDriverDeployed != "" {
+		holders, err := dm.kubeClient.GetGPUResourceClaimHolders(dm.config.nodeName)
+		if err != nil {
+			dm.cleanupOnFailure()
+			return fmt.Errorf("failed to check for GPU resource claim holders: %w", err)
+		}
+		if len(holders) > 0 {
+			dm.cleanupOnFailure()
+			return fmt.Errorf("cannot drain the DRA kubelet-plugin: pod(s) still hold GPU resource claims: %s", strings.Join(holders, ", "))
+		}
+	}
+
+	// Drain the kubelet-plugin after the claim-holders and GPU workloads are gone but
+	// before the driver is unloaded, so the kubelet can still reach it to release their
+	// DRA claims.
+	if err := dm.evictKubeletPlugin(); err != nil {
+		dm.cleanupOnFailure()
+		return fmt.Errorf("failed to evict DRA kubelet-plugin: %w", err)
 	}
 
 	// Check if driver is loaded and cleanup if needed
@@ -475,6 +514,8 @@ func (dm *DriverManager) fetchCurrentLabels() error {
 		nvidiaSandboxDevicePluginDeployLabel,
 		nvidiaVGPUDeviceManagerDeployLabel,
 		nvidiaGPUClientDeployLabel,
+		nvidiaDRADriverDeployLabel,
+		nvidiaDRAValidatorDeployLabel,
 	}
 
 	for _, label := range operandLabels {
@@ -527,6 +568,10 @@ func (dm *DriverManager) setComponentState(label, value string) {
 		dm.components.vgpuDeviceManagerDeployed = value
 	case nvidiaGPUClientDeployLabel:
 		dm.components.gpuClientsDeployed = value
+	case nvidiaDRADriverDeployLabel:
+		dm.components.draDriverDeployed = value
+	case nvidiaDRAValidatorDeployLabel:
+		dm.components.draValidatorDeployed = value
 	}
 }
 
@@ -564,6 +609,12 @@ func (dm *DriverManager) evictAllGPUOperatorComponents() error {
 		operandLabels[nvidiaMIGManagerDeployLabel] = dm.maybeSetPaused(dm.components.migManagerDeployed)
 	}
 
+	// The dra-validator holds a DRA claim, so it drains here with the other clients. The
+	// kubelet-plugin that services that claim is drained separately, after them.
+	if dm.components.draValidatorDeployed != "" {
+		operandLabels[nvidiaDRAValidatorDeployLabel] = dm.maybeSetPaused(dm.components.draValidatorDeployed)
+	}
+
 	// Handle custom operand node selector label
 	if dm.components.customOperandNodeLabelValue != "" {
 		dm.log.Infof("Shutting down GPU clients using node selector label %q=%s", dm.config.nodeLabelForGPUPodEviction, dm.components.customOperandNodeLabelValue)
@@ -582,6 +633,34 @@ func (dm *DriverManager) evictAllGPUOperatorComponents() error {
 
 	// Wait for pods to terminate
 	return dm.waitForPodsToTerminate()
+}
+
+// evictKubeletPlugin drains the DRA kubelet-plugin after the other GPU clients, not in
+// the same batch. It services NodeUnprepareResources for every claim-holder (e.g.
+// dra-validator, gpu-feature-discovery), so it must outlive them; draining it alongside
+// them would deadlock, since they cannot finish terminating without it.
+func (dm *DriverManager) evictKubeletPlugin() error {
+	if dm.components.draDriverDeployed == "" {
+		return nil
+	}
+
+	dm.log.Info("Draining the DRA kubelet-plugin (last, after its claim-holding clients)")
+	operandLabels := map[string]string{
+		nvidiaDRADriverDeployLabel: dm.maybeSetPaused(dm.components.draDriverDeployed),
+	}
+	if err := dm.kubeClient.UpdateNodeLabels(dm.config.nodeName, operandLabels); err != nil {
+		return err
+	}
+
+	dm.log.Info("Waiting for dra-driver to shutdown")
+	selectorMap := map[string]string{
+		"app": "nvidia-dra-driver-kubelet-plugin",
+	}
+	if err := dm.kubeClient.WaitForPodTermination(selectorMap, dm.config.operatorNamespace, dm.config.nodeName, defaultGracePeriod); err != nil {
+		dm.log.Errorf("Failed to wait for dra-driver to shutdown: %v", err)
+		return err
+	}
+	return nil
 }
 
 func (dm *DriverManager) maybeSetPaused(currentValue string) string {
@@ -603,12 +682,19 @@ func (dm *DriverManager) waitForPodsToTerminate() error {
 		app     string
 		timeout time.Duration
 	}{
+		// The ClusterPolicy and GPUCluster validators intentionally share this pod
+		// label so the upgrade controller and driver-manager use the same readiness
+		// and shutdown gate.
 		{"nvidia-operator-validator", defaultGracePeriod},
 		{"nvidia-container-toolkit-daemonset", defaultGracePeriod},
 		{"nvidia-device-plugin-daemonset", defaultGracePeriod},
 		{"gpu-feature-discovery", defaultGracePeriod},
 		{"nvidia-dcgm-exporter", defaultGracePeriod},
 		{"nvidia-dcgm", defaultGracePeriod},
+		// The DRA-mode DCGM operands share the gpu.deploy.dcgm* node-selector
+		// labels with the ones above but carry distinct app labels.
+		{"nvidia-dcgm-exporter-dra", defaultGracePeriod},
+		{"nvidia-dcgm-dra", defaultGracePeriod},
 	}
 
 	namespace := dm.config.operatorNamespace
@@ -907,6 +993,14 @@ func (dm *DriverManager) rescheduleGPUOperatorComponents() error {
 
 	if dm.components.migManagerDeployed != "" {
 		operandLabels[nvidiaMIGManagerDeployLabel] = dm.maybeSetTrue(dm.components.migManagerDeployed)
+	}
+
+	if dm.components.draDriverDeployed != "" {
+		operandLabels[nvidiaDRADriverDeployLabel] = dm.maybeSetTrue(dm.components.draDriverDeployed)
+	}
+
+	if dm.components.draValidatorDeployed != "" {
+		operandLabels[nvidiaDRAValidatorDeployLabel] = dm.maybeSetTrue(dm.components.draValidatorDeployed)
 	}
 
 	// Handle custom operand node selector label

--- a/internal/kubernetes/client.go
+++ b/internal/kubernetes/client.go
@@ -218,6 +218,35 @@ func (c *Client) WaitForPodsWithNodeSelector(nodeName, nodeSelectorKey string, t
 	})
 }
 
+// GetGPUResourceClaimHolders returns the namespaced names of the pods on the node which
+// still hold a ResourceClaim allocated by the NVIDIA GPU DRA driver, i.e. the pods the
+// kubelet still needs the DRA kubelet-plugin to unprepare. Pods in a terminal phase are
+// excluded, since the kubelet has unprepared their claims by then.
+func (c *Client) GetGPUResourceClaimHolders(nodeName string) ([]string, error) {
+	podList, err := c.clientset.CoreV1().Pods(corev1.NamespaceAll).List(c.ctx, metav1.ListOptions{
+		FieldSelector: fields.OneTermEqualSelector("spec.nodeName", nodeName).String(),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to list pods on node %s: %w", nodeName, err)
+	}
+
+	var holders []string
+	for _, pod := range podList.Items {
+		if pod.Status.Phase == corev1.PodSucceeded || pod.Status.Phase == corev1.PodFailed {
+			continue
+		}
+		hasClaim, err := c.podHasGPUResourceClaim(pod)
+		if err != nil {
+			return nil, err
+		}
+		if hasClaim {
+			holders = append(holders, pod.Namespace+"/"+pod.Name)
+		}
+	}
+
+	return holders, nil
+}
+
 // DrainNode drains a Node given a Node name and a set of drain option parameters
 func (c *Client) DrainNode(nodeName string, drainOpts DrainOptions) error {
 	c.log.Infof("Draining node %s", nodeName)


### PR DESCRIPTION
This PR adds the NVIDIA DRA driver `kubelet-plugin` and the DRA validator to the set of GPU clients that the `driver-manager` drains off a node before reloading the driver. When the GPU Operator manages GPUs through Dynamic Resource Allocation (the new DRA CRD path), these pods hold the driver just like the device-plugin, GFD, and DCGM do today, so they must be drained and recreated across a driver reload. Otherwise the `kubelet-plugin` keeps serving CDI specs enumerated against the old driver and GPU claims fail until it is manually restarted.

All new behavior is gated on the `nvidia.com/gpu.deploy.dra-driver` and `nvidia.com/gpu.deploy.dra-validator` node labels, so deployments without the DRA stack are unaffected, mirroring the existing optional components (mig-manager, sandbox-*, vgpu-device-manager). 

Functionally, this PR depends on companion GPU Operator changes that set those labels and add the matching `nodeSelector` to the kubelet-plugin and validator DaemonSets.

## Testing
I tested the following scenarios manually on a 2-node cluster (A100 worker + T4 control-plane) running the GPU Operator DRA stack:

- I deployed the DRA stack and verify the kubelet-plugin and dra-validator are labeled with `nvidia.com/gpu.deploy.dra-driver=true` and `nvidia.com/gpu.deploy.dra-validator=true` and come up on each GPU node.
- Then, I triggered a driver upgrade by bumping the NVIDIADriver version. I verified the driver-manager drains the validator and GFD first, then the kubelet-plugin, reloads the driver, and restores them. Both nodes completed the rolling upgrade with no pods stuck `Terminating`. I verified the kubelet-plugin pods were recreated, re-enumerated against the new driver, and a GPU claim succeeded on each node afterward.
- I verified that drain ordering is required. I found that draining the kubelet-plugin in the same batch as the claim-holders left the validator and GFD stuck `Terminating` (their DRA claims cannot be released once the plugin is gone) and deadlocked the upgrade, so draining the plugin last after them avoids this.
