### PR TITLE
add ability to bounce custom gpu client pods

### DIFF
--- a/cmd/driver-manager/main.go
+++ b/cmd/driver-manager/main.go
@@ -62,6 +62,7 @@ const (
 	nvidiaSandboxValidatorDeployLabel    = nvidiaDomainPrefix + "/" + "gpu.deploy.sandbox-validator"
 	nvidiaSandboxDevicePluginDeployLabel = nvidiaDomainPrefix + "/" + "gpu.deploy.sandbox-device-plugin"
 	nvidiaVGPUDeviceManagerDeployLabel   = nvidiaDomainPrefix + "/" + "gpu.deploy.vgpu-device-manager"
+	nvidiaGPUClientDeployLabel           = nvidiaDomainPrefix + "/" + "gpu.deploy.client"
 )
 
 // Configuration holds all the configuration from environment variables
@@ -95,6 +96,7 @@ type componentState struct {
 	sandboxPluginDeployed       string
 	vgpuDeviceManagerDeployed   string
 	customOperandNodeLabelValue string
+	gpuClientsDeployed          string
 	autoUpgradePolicyEnabled    string
 }
 
@@ -472,6 +474,7 @@ func (dm *DriverManager) fetchCurrentLabels() error {
 		nvidiaSandboxValidatorDeployLabel,
 		nvidiaSandboxDevicePluginDeployLabel,
 		nvidiaVGPUDeviceManagerDeployLabel,
+		nvidiaGPUClientDeployLabel,
 	}
 
 	for _, label := range operandLabels {
@@ -522,6 +525,8 @@ func (dm *DriverManager) setComponentState(label, value string) {
 		dm.components.sandboxPluginDeployed = value
 	case nvidiaVGPUDeviceManagerDeployLabel:
 		dm.components.vgpuDeviceManagerDeployed = value
+	case nvidiaGPUClientDeployLabel:
+		dm.components.gpuClientsDeployed = value
 	}
 }
 
@@ -563,6 +568,10 @@ func (dm *DriverManager) evictAllGPUOperatorComponents() error {
 	if dm.components.customOperandNodeLabelValue != "" {
 		dm.log.Infof("Shutting down GPU clients using node selector label %q=%s", dm.config.nodeLabelForGPUPodEviction, dm.components.customOperandNodeLabelValue)
 		operandLabels[dm.config.nodeLabelForGPUPodEviction] = dm.maybeSetPaused(dm.components.customOperandNodeLabelValue)
+	}
+
+	if dm.components.gpuClientsDeployed != "" {
+		operandLabels[nvidiaGPUClientDeployLabel] = dm.maybeSetPaused(dm.components.gpuClientsDeployed)
 	}
 
 	// Update the node
@@ -657,6 +666,15 @@ func (dm *DriverManager) waitForPodsToTerminate() error {
 		}
 		if err := dm.kubeClient.WaitForPodTermination(selectorMap, namespace, nodeName, defaultGracePeriod); err != nil {
 			dm.log.Errorf("Failed to wait for vgpu-device-manager to shutdown: %v", err)
+			return err
+		}
+	}
+
+	// Wait for any pods whose parent controller uses nvidia.com/gpu.deploy.client as a nodeSelector key.
+	if dm.components.gpuClientsDeployed != "" {
+		dm.log.Infof("Waiting for any daemon set pods with nodeSelector key %s to terminate", nvidiaGPUClientDeployLabel)
+		if err := dm.kubeClient.WaitForPodsWithNodeSelector(nodeName, nvidiaGPUClientDeployLabel, defaultGracePeriod); err != nil {
+			dm.log.Errorf("Failed to wait for GPU client pods to terminate: %v", err)
 			return err
 		}
 	}
@@ -894,6 +912,10 @@ func (dm *DriverManager) rescheduleGPUOperatorComponents() error {
 	// Handle custom operand node selector label
 	if dm.components.customOperandNodeLabelValue != "" {
 		operandLabels[dm.config.nodeLabelForGPUPodEviction] = dm.maybeSetTrue(dm.components.customOperandNodeLabelValue)
+	}
+
+	if dm.components.gpuClientsDeployed != "" {
+		operandLabels[nvidiaGPUClientDeployLabel] = dm.maybeSetTrue(dm.components.gpuClientsDeployed)
 	}
 
 	// Update the node

--- a/internal/kubernetes/client.go
+++ b/internal/kubernetes/client.go
@@ -27,6 +27,7 @@ import (
 	"github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -41,6 +42,8 @@ const (
 	nvidiaDomainPrefix       = "nvidia.com"
 	nvidiaResourceNamePrefix = nvidiaDomainPrefix + "/" + "gpu"
 	nvidiaMigResourcePrefix  = nvidiaDomainPrefix + "/" + "mig-"
+
+	kubeClientPollInterval = 5 * time.Second
 )
 
 // Client represents a Kubernetes client wrapper use to perform all the Kubernetes operations required by k8s-driver-manager
@@ -169,10 +172,10 @@ func (c *Client) UncordonNode(nodeName string) error {
 func (c *Client) WaitForPodTermination(selectorMap map[string]string, namespace, nodeName string, timeout time.Duration) error {
 	selector := labels.SelectorFromSet(selectorMap)
 
-	return wait.PollUntilContextTimeout(c.ctx, 5*time.Second, timeout, true, func(ctx context.Context) (bool, error) {
+	return wait.PollUntilContextTimeout(c.ctx, kubeClientPollInterval, timeout, true, func(ctx context.Context) (bool, error) {
 		pods, err := c.clientset.CoreV1().Pods(namespace).List(c.ctx, metav1.ListOptions{
 			LabelSelector: selector.String(),
-			FieldSelector: "spec.nodeName=" + nodeName,
+			FieldSelector: fields.OneTermEqualSelector("spec.nodeName", nodeName).String(),
 		})
 		if err != nil {
 			return false, err
@@ -180,6 +183,35 @@ func (c *Client) WaitForPodTermination(selectorMap map[string]string, namespace,
 
 		// Return true if no pods are found (all terminated)
 		return len(pods.Items) == 0, nil
+	})
+}
+
+// WaitForPodsWithNodeSelector waits for all daemon set pods on the given node which has the specified key in
+// its nodeSelector to terminate.
+func (c *Client) WaitForPodsWithNodeSelector(nodeName, nodeSelectorKey string, timeout time.Duration) error {
+	return wait.PollUntilContextTimeout(c.ctx, kubeClientPollInterval, timeout, true, func(ctx context.Context) (bool, error) {
+		podList, err := c.clientset.CoreV1().Pods(corev1.NamespaceAll).List(ctx, metav1.ListOptions{
+			FieldSelector: fields.OneTermEqualSelector("spec.nodeName", nodeName).String(),
+		})
+		if err != nil {
+			return false, fmt.Errorf("failed to list pods on node %s: %w", nodeName, err)
+		}
+
+		matchCount := 0
+		for _, pod := range podList.Items {
+			ownerRef := metav1.GetControllerOf(&pod)
+			if ownerRef == nil || ownerRef.Kind != "DaemonSet" {
+				continue
+			}
+			if _, ok := pod.Spec.NodeSelector[nodeSelectorKey]; ok {
+				matchCount++
+			}
+		}
+
+		if matchCount > 0 {
+			c.log.Infof("Waiting for %d daemon set pod(s) with nodeSelector key %q to terminate", matchCount, nodeSelectorKey)
+		}
+		return matchCount == 0, nil
 	})
 }
 


### PR DESCRIPTION
This PR is linked to https://github.com/NVIDIA/gpu-operator/pull/2607.

This adds the ability for the `k8s-driver-manager` to detect third-party/custom gpu client pods during driver upgrades and to evict them as they too will be holding onto gpu device handles. With this change, users can deploy their custom gpu client pods and also take advantage of the automatic toggling of gpu client components (just as what is done for the first-class gpu clients namely the "operands") during a driver upgrade.

**NOTE**: The third-party gpu client pods MUST add the `nvidia.com/gpu.deploy.client: true` label to its nodeSelector so that the k8s-driver-manager detects and performs the automated toggle during a driver upgrade