### PR TITLE
retry the cordon and uncordon of a node on transient API errors

### DIFF
--- a/cmd/driver-manager/main.go
+++ b/cmd/driver-manager/main.go
@@ -40,13 +40,14 @@ import (
 )
 
 const (
-	driverRoot            = "/run/nvidia/driver"
-	driverPIDFile         = "/run/nvidia/nvidia-driver.pid"
-	driverConfigStateFile = "/run/nvidia/nvidia-driver.state"
-	operatorNamespace     = "gpu-operator"
-	pausedStr             = "paused-for-driver-upgrade"
-	defaultDrainTimeout   = time.Second * 0
-	defaultGracePeriod    = 5 * time.Minute
+	driverRoot             = "/run/nvidia/driver"
+	driverPIDFile          = "/run/nvidia/nvidia-driver.pid"
+	driverConfigStateFile  = "/run/nvidia/nvidia-driver.state"
+	operatorNamespace      = "gpu-operator"
+	pausedStr              = "paused-for-driver-upgrade"
+	defaultDrainTimeout    = time.Second * 0
+	defaultGracePeriod     = 5 * time.Minute
+	defaultUncordonRetries = 5
 
 	nvidiaDomainPrefix = "nvidia.com"
 
@@ -402,8 +403,8 @@ func (dm *DriverManager) uninstallDriver() error {
 
 	// Cleanup and reschedule components
 	if dm.isGPUPodEvictionEnabled() || dm.isAutoDrainEnabled() {
-		if err := dm.kubeClient.UncordonNode(dm.config.nodeName); err != nil {
-			dm.log.Warnf("Failed to uncordon node: %v", err)
+		if err := dm.kubeClient.UncordonNode(dm.config.nodeName, kube.RetryBackoff(defaultUncordonRetries)); err != nil {
+			return fmt.Errorf("failed to uncordon node: %w", err)
 		}
 	}
 
@@ -980,7 +981,7 @@ func (dm *DriverManager) cleanupOnFailure() {
 
 	switch {
 	case managerCanEvict:
-		if err := dm.kubeClient.UncordonNode(dm.config.nodeName); err != nil {
+		if err := dm.kubeClient.UncordonNode(dm.config.nodeName, kube.RetryBackoff(defaultUncordonRetries)); err != nil {
 			dm.log.Warnf("Failed to uncordon node during cleanup: %v", err)
 		}
 	case policyEnabled:

--- a/cmd/driver-manager/main.go
+++ b/cmd/driver-manager/main.go
@@ -47,6 +47,10 @@ const (
 	pausedStr             = "paused-for-driver-upgrade"
 	defaultDrainTimeout   = time.Second * 0
 	defaultGracePeriod    = 5 * time.Minute
+	// defaultCordonRetries bounds the retries for the cordon and uncordon calls
+	// that bracket the driver uninstall, so a transient API server error does not
+	// abort an upgrade or leave the node cordoned.
+	defaultCordonRetries = 5
 
 	nvidiaDomainPrefix = "nvidia.com"
 
@@ -344,7 +348,7 @@ func (dm *DriverManager) uninstallDriver() error {
 		}
 
 		if dm.isGPUPodEvictionEnabled() || dm.isAutoDrainEnabled() {
-			if err := dm.kubeClient.UncordonNode(dm.config.nodeName); err != nil {
+			if err := dm.uncordonNode(); err != nil {
 				dm.log.Warnf("Failed to uncordon node: %v", err)
 			}
 		}
@@ -407,7 +411,7 @@ func (dm *DriverManager) uninstallDriver() error {
 	// the post-unload auto-drain fallback runs after the kubelet-plugin is gone,
 	// leaving drained claim-holders stuck in Terminating.
 	if dm.isGPUPodEvictionEnabled() || (dm.components.draDriverDeployed != "" && dm.isAutoDrainEnabled()) {
-		if err := dm.kubeClient.CordonNode(dm.config.nodeName); err != nil {
+		if err := dm.cordonNode(); err != nil {
 			return fmt.Errorf("failed to cordon node: %w", err)
 		}
 
@@ -500,7 +504,7 @@ func (dm *DriverManager) uninstallDriver() error {
 
 	// Cleanup and reschedule components
 	if dm.isGPUPodEvictionEnabled() || dm.isAutoDrainEnabled() {
-		if err := dm.kubeClient.UncordonNode(dm.config.nodeName); err != nil {
+		if err := dm.uncordonNode(); err != nil {
 			dm.log.Warnf("Failed to uncordon node: %v", err)
 		}
 	}
@@ -1123,6 +1127,21 @@ func (dm *DriverManager) isDriverAutoUpgradePolicyEnabled() bool {
 	return false
 }
 
+// cordonNode and uncordonNode wrap the kube client calls with this command's
+// retry policy. The policy lives here rather than in the client so the client
+// stays a thin wrapper over the Kubernetes API.
+func (dm *DriverManager) cordonNode() error {
+	return retryOnAnyError(dm.ctx, dm.log, retryBackoff(defaultCordonRetries),
+		fmt.Sprintf("cordon node %s", dm.config.nodeName),
+		func() error { return dm.kubeClient.CordonNode(dm.config.nodeName) })
+}
+
+func (dm *DriverManager) uncordonNode() error {
+	return retryOnAnyError(dm.ctx, dm.log, retryBackoff(defaultCordonRetries),
+		fmt.Sprintf("uncordon node %s", dm.config.nodeName),
+		func() error { return dm.kubeClient.UncordonNode(dm.config.nodeName) })
+}
+
 func (dm *DriverManager) cleanupOnFailure() {
 	dm.log.Info("Performing cleanup on failure")
 	policyEnabled := dm.isDriverAutoUpgradePolicyEnabled()
@@ -1130,7 +1149,7 @@ func (dm *DriverManager) cleanupOnFailure() {
 
 	switch {
 	case managerCanEvict:
-		if err := dm.kubeClient.UncordonNode(dm.config.nodeName); err != nil {
+		if err := dm.uncordonNode(); err != nil {
 			dm.log.Warnf("Failed to uncordon node during cleanup: %v", err)
 		}
 	case policyEnabled:

--- a/cmd/driver-manager/retry.go
+++ b/cmd/driver-manager/retry.go
@@ -1,0 +1,82 @@
+//go:build !darwin && !windows
+
+/*
+ * Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package main
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/sirupsen/logrus"
+	"k8s.io/apimachinery/pkg/util/wait"
+)
+
+// retryBackoff returns the exponential backoff used to retry transient
+// Kubernetes API errors, bounded to the given number of attempts (at least one).
+func retryBackoff(attempts int) wait.Backoff {
+	if attempts < 1 {
+		attempts = 1
+	}
+	return wait.Backoff{Duration: time.Second, Factor: 2.0, Jitter: 0.2, Steps: attempts}
+}
+
+// retryOnAnyError retries fn on any error using the given backoff, logging each
+// failed attempt at action. A cancelled ctx ends the retry loop promptly instead
+// of sleeping out the remaining backoff, and is joined with the last error
+// rather than being reduced to it, which wait.Interrupted would otherwise
+// conflate.
+func retryOnAnyError(ctx context.Context, log *logrus.Logger, backoff wait.Backoff, action string, fn func() error) error {
+	maxAttempts := backoff.Steps
+	attempt := 0
+
+	var lastErr error
+
+	err := wait.ExponentialBackoffWithContext(ctx, backoff, func(context.Context) (bool, error) {
+		attempt++
+
+		lastErr = fn()
+		if lastErr == nil {
+			return true, nil
+		}
+		logFailedAttempt(log, action, attempt, maxAttempts, lastErr)
+		return false, nil
+	})
+	if err == nil {
+		return nil
+	}
+
+	if ctxErr := ctx.Err(); ctxErr != nil {
+		return errors.Join(ctxErr, lastErr)
+	}
+	if lastErr != nil {
+		return lastErr
+	}
+	return err
+}
+
+// logFailedAttempt reports a failed attempt at action, distinguishing a retry
+// from the attempt that exhausts the budget so the final failure is not
+// misreported as "retrying".
+func logFailedAttempt(log *logrus.Logger, action string, attempt, maxAttempts int, err error) {
+	if attempt < maxAttempts {
+		log.Warnf("Failed to %s (attempt %d/%d), retrying: %v", action, attempt, maxAttempts, err)
+		return
+	}
+	log.Errorf("Failed to %s (attempt %d/%d), giving up: %v", action, attempt, maxAttempts, err)
+}

--- a/cmd/driver-manager/retry_test.go
+++ b/cmd/driver-manager/retry_test.go
@@ -1,0 +1,132 @@
+//go:build !darwin && !windows
+
+/*
+ * Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"testing"
+	"time"
+
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/util/wait"
+)
+
+// fastBackoff keeps retries near-instant so tests do not sleep.
+func fastBackoff(steps int) wait.Backoff {
+	return wait.Backoff{Duration: time.Millisecond, Factor: 1.0, Steps: steps}
+}
+
+func discardLogger() *logrus.Logger {
+	log := logrus.New()
+	log.SetOutput(io.Discard)
+	return log
+}
+
+func TestRetryOnAnyErrorRetriesUntilSuccess(t *testing.T) {
+	attempts := 0
+	err := retryOnAnyError(context.Background(), discardLogger(), fastBackoff(5), "cordon node", func() error {
+		attempts++
+		if attempts < 3 {
+			return fmt.Errorf("api-server timeout")
+		}
+		return nil
+	})
+	require.NoError(t, err)
+	require.Equal(t, 3, attempts)
+}
+
+func TestRetryOnAnyErrorReturnsLastErrorWhenExhausted(t *testing.T) {
+	attempts := 0
+	err := retryOnAnyError(context.Background(), discardLogger(), fastBackoff(3), "uncordon node", func() error {
+		attempts++
+		return fmt.Errorf("api-server down")
+	})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "api-server down")
+	require.Equal(t, 3, attempts)
+}
+
+func TestRetryBackoffAlwaysAttemptsAtLeastOnce(t *testing.T) {
+	require.GreaterOrEqual(t, retryBackoff(0).Steps, 1)
+	require.Equal(t, 5, retryBackoff(5).Steps)
+}
+
+func TestRetryOnAnyErrorStopsPromptlyWhenContextCancelled(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// A backoff this long would hang the test if the remaining sleep were not
+	// cut short by the cancelled context.
+	backoff := wait.Backoff{Duration: time.Hour, Factor: 1.0, Steps: 5}
+
+	attempts := 0
+	start := time.Now()
+	err := retryOnAnyError(ctx, discardLogger(), backoff, "uncordon node", func() error {
+		attempts++
+		cancel()
+		return fmt.Errorf("api-server down")
+	})
+
+	require.ErrorIs(t, err, context.Canceled)
+	require.Equal(t, 1, attempts)
+	require.Less(t, time.Since(start), 30*time.Second)
+}
+
+func TestRetryOnAnyErrorJoinsCancellationWithLastError(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	sentinel := fmt.Errorf("api-server down")
+	err := retryOnAnyError(ctx, discardLogger(), fastBackoff(5), "uncordon node", func() error {
+		cancel()
+		return sentinel
+	})
+
+	// errors.Join keeps both causes inspectable rather than flattening them
+	// into a message.
+	require.ErrorIs(t, err, context.Canceled)
+	require.ErrorIs(t, err, sentinel)
+}
+
+func TestLogFailedAttemptOnlyPromisesARetryWhileAttemptsRemain(t *testing.T) {
+	log := logrus.New()
+	log.SetOutput(io.Discard)
+
+	var levels []logrus.Level
+	log.AddHook(collectLevels(&levels))
+
+	logFailedAttempt(log, "cordon node", 1, 3, fmt.Errorf("boom"))
+	logFailedAttempt(log, "cordon node", 3, 3, fmt.Errorf("boom"))
+
+	require.Equal(t, []logrus.Level{logrus.WarnLevel, logrus.ErrorLevel}, levels)
+}
+
+type levelCollector struct{ levels *[]logrus.Level }
+
+func (c levelCollector) Levels() []logrus.Level { return logrus.AllLevels }
+
+func (c levelCollector) Fire(entry *logrus.Entry) error {
+	*c.levels = append(*c.levels, entry.Level)
+	return nil
+}
+
+func collectLevels(levels *[]logrus.Level) logrus.Hook { return levelCollector{levels: levels} }

--- a/internal/kubernetes/client.go
+++ b/internal/kubernetes/client.go
@@ -111,16 +111,7 @@ func (c *Client) UpdateNodeLabels(nodeName string, nodeLabels map[string]string)
 		return fmt.Errorf("failed to marshal patch: %w", err)
 	}
 
-	backoff := wait.Backoff{
-		Duration: time.Second,
-		Factor:   2.0,
-		Jitter:   0.2,
-		Steps:    7,
-	}
-
-	return retry.OnError(backoff, func(err error) bool {
-		return true
-	}, func() error {
+	return retryOnAnyError(RetryBackoff(7), func() error {
 		_, err := c.clientset.CoreV1().Nodes().Patch(c.ctx, nodeName, types.StrategicMergePatchType, patchBytes, metav1.PatchOptions{})
 		if err != nil {
 			c.log.Warnf("Failed to update labels on node %s, retrying: %v", nodeName, err)
@@ -154,17 +145,34 @@ func (c *Client) CordonNode(nodeName string) error {
 	return drain.RunCordonOrUncordon(drainHelper, node, true)
 }
 
-// UncordonNode uncordons a Node given a Node name marking it as Schedulable
-func (c *Client) UncordonNode(nodeName string) error {
+// RetryBackoff returns the exponential backoff used to retry transient
+// Kubernetes API errors, bounded to the given number of attempts (at least one).
+func RetryBackoff(attempts int) wait.Backoff {
+	if attempts < 1 {
+		attempts = 1
+	}
+	return wait.Backoff{Duration: time.Second, Factor: 2.0, Jitter: 0.2, Steps: attempts}
+}
+
+// retryOnAnyError retries fn on any error using the given backoff.
+func retryOnAnyError(backoff wait.Backoff, fn func() error) error {
+	return retry.OnError(backoff, func(error) bool { return true }, fn)
+}
+
+// UncordonNode uncordons a Node given a Node name marking it as Schedulable.
+// It retries on any error until the backoff budget is exhausted, then returns
+// the last error so a stuck-cordoned node fails loudly instead of silently.
+func (c *Client) UncordonNode(nodeName string, backoff wait.Backoff) error {
 	c.log.Infof("Uncordoning node %s", nodeName)
 
-	node, err := c.clientset.CoreV1().Nodes().Get(c.ctx, nodeName, metav1.GetOptions{})
-	if err != nil {
-		return fmt.Errorf("failed to get node %s: %w", nodeName, err)
-	}
-
-	drainHelper := &drain.Helper{Ctx: c.ctx, Client: c.clientset}
-	return drain.RunCordonOrUncordon(drainHelper, node, false)
+	return retryOnAnyError(backoff, func() error {
+		node, err := c.clientset.CoreV1().Nodes().Get(c.ctx, nodeName, metav1.GetOptions{})
+		if err != nil {
+			return fmt.Errorf("failed to get node %s: %w", nodeName, err)
+		}
+		drainHelper := &drain.Helper{Ctx: c.ctx, Client: c.clientset}
+		return drain.RunCordonOrUncordon(drainHelper, node, false)
+	})
 }
 
 // WaitForPodTermination will wait for the termination of pods matching labels from the selectorMap on the node with the specified namespace.

--- a/internal/kubernetes/client_test.go
+++ b/internal/kubernetes/client_test.go
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package kubernetes
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/util/wait"
+)
+
+// fastBackoff keeps retries near-instant so tests do not sleep.
+func fastBackoff(steps int) wait.Backoff {
+	return wait.Backoff{Duration: time.Millisecond, Factor: 1.0, Steps: steps}
+}
+
+func TestRetryOnAnyErrorRetriesUntilSuccess(t *testing.T) {
+	attempts := 0
+	err := retryOnAnyError(fastBackoff(5), func() error {
+		attempts++
+		if attempts < 3 {
+			return fmt.Errorf("api-server timeout")
+		}
+		return nil
+	})
+	require.NoError(t, err)
+	require.Equal(t, 3, attempts)
+}
+
+func TestRetryOnAnyErrorReturnsLastErrorWhenExhausted(t *testing.T) {
+	attempts := 0
+	err := retryOnAnyError(fastBackoff(3), func() error {
+		attempts++
+		return fmt.Errorf("api-server down")
+	})
+	require.Error(t, err)
+	require.Equal(t, 3, attempts)
+}
+
+func TestRetryBackoffAlwaysAttemptsAtLeastOnce(t *testing.T) {
+	require.GreaterOrEqual(t, RetryBackoff(0).Steps, 1)
+	require.Equal(t, 5, RetryBackoff(5).Steps)
+}

--- a/internal/kubernetes/client_test.go
+++ b/internal/kubernetes/client_test.go
@@ -1,0 +1,197 @@
+/*
+ * Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package kubernetes
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+)
+
+// flakyNodeAPI is a minimal stand-in for the Kubernetes API server that serves a
+// single Node and fails the first getFailures reads and patchFailures writes
+// with a 500, mimicking an API server that is not yet ready when the driver
+// manager starts.
+type flakyNodeAPI struct {
+	mu            sync.Mutex
+	nodeName      string
+	getFailures   int
+	patchFailures int
+	requests      int
+	patches       int
+	unschedulable bool
+}
+
+func (f *flakyNodeAPI) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	f.requests++
+
+	// The cordon path is a read followed by a write, and either half can fail
+	// independently, so the failure budgets are tracked per verb.
+	write := r.Method == http.MethodPatch || r.Method == http.MethodPut
+	if write {
+		f.patches++
+		if f.patchFailures > 0 {
+			f.patchFailures--
+			http.Error(w, "the server rejected the update", http.StatusInternalServerError)
+			return
+		}
+	} else if f.getFailures > 0 {
+		f.getFailures--
+		http.Error(w, "the server is currently unable to handle the request", http.StatusInternalServerError)
+		return
+	}
+
+	if write {
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		// A strategic merge patch clears spec.unschedulable with a null rather
+		// than setting it to false, so key presence is what matters here.
+		var patch map[string]any
+		if err := json.Unmarshal(body, &patch); err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		if spec, ok := patch["spec"].(map[string]any); ok {
+			if value, present := spec["unschedulable"]; present {
+				cordoned, _ := value.(bool)
+				f.unschedulable = cordoned
+			}
+		}
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	node := &corev1.Node{
+		TypeMeta:   metav1.TypeMeta{Kind: "Node", APIVersion: "v1"},
+		ObjectMeta: metav1.ObjectMeta{Name: f.nodeName},
+		Spec:       corev1.NodeSpec{Unschedulable: f.unschedulable},
+	}
+	if err := json.NewEncoder(w).Encode(node); err != nil {
+		f.requests-- // the request never completed, do not count it
+	}
+}
+
+func (f *flakyNodeAPI) requestCount() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.requests
+}
+
+func (f *flakyNodeAPI) cordoned() bool {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.unschedulable
+}
+
+func discardLogger() *logrus.Logger {
+	log := logrus.New()
+	log.SetOutput(io.Discard)
+	return log
+}
+
+func newTestClient(t *testing.T, api *flakyNodeAPI) *Client {
+	t.Helper()
+
+	server := httptest.NewServer(api)
+	t.Cleanup(server.Close)
+
+	clientset, err := kubernetes.NewForConfig(&rest.Config{Host: server.URL})
+	require.NoError(t, err)
+
+	return &Client{ctx: context.Background(), log: discardLogger(), clientset: clientset}
+}
+
+func (f *flakyNodeAPI) patchCount() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.patches
+}
+
+// The client makes one attempt per call: the retry policy lives in the
+// driver-manager command, not here.
+func TestCordonNodeCordonsTheNode(t *testing.T) {
+	api := &flakyNodeAPI{nodeName: "gpu-node"}
+	c := newTestClient(t, api)
+
+	require.NoError(t, c.CordonNode("gpu-node"))
+	require.True(t, api.cordoned())
+	// One read followed by one write.
+	require.Equal(t, 1, api.patchCount())
+	require.Equal(t, 2, api.requestCount())
+}
+
+func TestUncordonNodeUncordonsTheNode(t *testing.T) {
+	api := &flakyNodeAPI{nodeName: "gpu-node", unschedulable: true}
+	c := newTestClient(t, api)
+
+	require.NoError(t, c.UncordonNode("gpu-node"))
+	require.False(t, api.cordoned())
+	require.Equal(t, 1, api.patchCount())
+	require.Equal(t, 2, api.requestCount())
+}
+
+func TestCordonNodeReturnsErrorWhenGetFails(t *testing.T) {
+	api := &flakyNodeAPI{nodeName: "gpu-node", getFailures: 1}
+	c := newTestClient(t, api)
+
+	require.Error(t, c.CordonNode("gpu-node"))
+	require.False(t, api.cordoned())
+	require.Equal(t, 1, api.requestCount())
+}
+
+func TestCordonNodeReturnsErrorWhenPatchFails(t *testing.T) {
+	api := &flakyNodeAPI{nodeName: "gpu-node", patchFailures: 1}
+	c := newTestClient(t, api)
+
+	require.Error(t, c.CordonNode("gpu-node"))
+	require.False(t, api.cordoned())
+	require.Equal(t, 1, api.patchCount())
+}
+
+func TestUncordonNodeReturnsErrorWhenGetFails(t *testing.T) {
+	api := &flakyNodeAPI{nodeName: "gpu-node", getFailures: 1, unschedulable: true}
+	c := newTestClient(t, api)
+
+	require.Error(t, c.UncordonNode("gpu-node"))
+	require.True(t, api.cordoned())
+	require.Equal(t, 1, api.requestCount())
+}
+
+func TestUncordonNodeReturnsErrorWhenPatchFails(t *testing.T) {
+	api := &flakyNodeAPI{nodeName: "gpu-node", patchFailures: 1, unschedulable: true}
+	c := newTestClient(t, api)
+
+	require.Error(t, c.UncordonNode("gpu-node"))
+	require.True(t, api.cordoned())
+	require.Equal(t, 1, api.patchCount())
+}


### PR DESCRIPTION
Relates to #190 — see the scope note at the end for why this does not close it.

`k8s-driver-manager` cordons the node, performs its driver work, then uncordons it. Both calls gave up on the first API error, so a transient API-server timeout, 5xx, or connection refused could abort an upgrade or leave the node cordoned. We hit this as our clusters come up for the first time, when the API server is not yet fully ready; it is not an issue during steady state or upgrades.

This wraps both calls in a bounded exponential backoff (5 attempts, 1s base, factor 2, 20% jitter — roughly 15s of retrying):

- The retry policy lives at the call site, in driver-manager's `cordonNode` and `uncordonNode`, so the kube client stays a thin wrapper over the Kubernetes API and carries no retry concern. `internal/kubernetes/client.go`, `go.mod` and `vendor/` are unchanged by this PR.
- Because the client reads the Node inside `CordonNode`/`UncordonNode`, a retried call always patches a freshly read object rather than a stale one.
- How each call site treats an exhausted budget is unchanged from today's behaviour.
- The retry loop is context aware: a cancelled context ends it promptly instead of sleeping out the remaining backoff, and is joined with the last error via `errors.Join` so both causes stay inspectable.
- Failed attempts are logged with their attempt number and only described as retrying while attempts remain, so the attempt that exhausts the budget is logged as a final failure instead.

There is no new env var or flag — the retry limit is a constant.

Tests: the retry helper is unit tested directly. The client's per-attempt contract is covered by driving the real typed clientset against an `httptest` stand-in API server with independent failure budgets for reads and writes, so both a failed GET and a failed PATCH are exercised. (`k8s.io/client-go/kubernetes/fake` is not vendored, and vendoring it would add a large unrelated diff.)

**Scope note.** Earlier revisions of this PR also propagated a failed uncordon so the init container exits non-zero instead of logging a warning and exiting 0. Per review that behavioural change is dropped here and will follow separately, leaving this PR limited to the retries. It is also why this does not close #190: the retries make a stuck `Ready,SchedulingDisabled` node far less likely, but an exhausted budget still leaves it cordoned silently.
