### PR TITLE
Skip eviction when no driver is loaded

### DIFF
--- a/cmd/driver-manager/main.go
+++ b/cmd/driver-manager/main.go
@@ -296,6 +296,61 @@ func (dm *DriverManager) uninstallDriver() error {
 		return fmt.Errorf("failed to fetch auto upgrade annotation: %w", err)
 	}
 
+	// No driver loaded (node reboot or fresh install): nothing holds the driver, so
+	// skip eviction. Evicting here deadlocks on DRA nodes: terminating a claim-holding
+	// pod needs the kubelet-plugin, which cannot start until the driver install
+	// proceeds.
+	if !dm.isDriverLoaded() {
+		dm.log.Info("No NVIDIA driver loaded, skipping eviction of GPU clients and workloads")
+
+		// Restart the kubelet-plugin: it stays bound to the previous driver rootfs
+		// and would fail to prepare claims against the replacement. Drain it before
+		// unmounting that rootfs so the unmount is not done underneath it.
+		if err := dm.evictKubeletPlugin(); err != nil {
+			return fmt.Errorf("failed to evict DRA kubelet-plugin: %w", err)
+		}
+
+		// Clean up stale artifacts from a previous driver container
+		if err := dm.unmountRootfs(); err != nil {
+			return fmt.Errorf("failed to unmount stale rootfs: %w", err)
+		}
+		dm.removePIDFile()
+
+		// Unload nouveau if present; it blocks the driver install
+		if dm.isNouveauLoaded() {
+			if err := dm.unloadNouveau(); err != nil {
+				return fmt.Errorf("failed to unload nouveau driver: %w", err)
+			}
+			dm.log.Info("Successfully unloaded nouveau driver")
+		}
+
+		// Handle vfio-pci driver unbinding
+		if err := dm.unbindVfioPCI(); err != nil {
+			dm.log.Error("Unable to unbind vfio-pci driver from all devices")
+			return fmt.Errorf("failed to unbind vfio-pci driver: %w", err)
+		}
+
+		// Handle GPUDirect RDMA if enabled
+		// When GPUDirectRDMA is enabled, wait until MOFED driver has finished installing
+		if dm.isGPUDirectRDMAEnabled() {
+			dm.log.Info("GPUDirectRDMA is enabled, validating MOFED driver installation")
+			if err := dm.waitForMofedDriver(); err != nil {
+				return fmt.Errorf("failed to wait for MOFED driver: %w", err)
+			}
+		}
+
+		if dm.isGPUPodEvictionEnabled() || dm.isAutoDrainEnabled() {
+			if err := dm.kubeClient.UncordonNode(dm.config.nodeName); err != nil {
+				dm.log.Warnf("Failed to uncordon node: %v", err)
+			}
+		}
+
+		if err := dm.rescheduleGPUOperatorComponents(); err != nil {
+			return fmt.Errorf("failed to reschedule GPU operator components: %w", err)
+		}
+		return nil
+	}
+
 	// Always evict all GPU operator components across a driver restart. The DRA
 	// kubelet-plugin is the exception: it services NodeUnprepareResources for the
 	// claim-holders evicted here (e.g. dra-validator), so it must outlive them and


### PR DESCRIPTION
> **Stacked on #203.** The base branch `kv-drain-dra-operands` mirrors #203's tip, so the diff here is only this PR's commit. After #203 merges I will retarget this PR to `main` and rebase.

Fixes #213.

## Problem

On a node reboot or fresh install, the driver-manager init container evicts all GPU operator components and drains GPU workloads before it allows the driver install to proceed. On a DRA node this deadlocks. A claim-holding pod cannot finish terminating until the kubelet calls `NodeUnprepareResources` on the DRA kubelet-plugin, and this obligation survives the reboot because the kubelet checkpoints prepared claims in `/var/lib/kubelet/dra_manager_state` (this is intentional kubelet behavior, see kubernetes/kubernetes#129402). The plugin cannot start until the driver is installed, and the driver cannot install until driver-manager finishes its evictions. The evicted pods stay in `Terminating` forever, and the init container crashloops on the eviction timeout while flapping the `gpu.deploy.*` labels.

The eviction also protects nothing in this state. With no NVIDIA kernel modules loaded, no process on the node holds the driver.

## Fix

I added an early exit at the top of `uninstallDriver`, above `evictAllGPUOperatorComponents()`, which is where the deadlock happens. When no NVIDIA kernel modules are loaded, driver-manager skips eviction and performs only the steps that must precede a fresh install.

- It unmounts a stale `/run/nvidia/driver` rootfs and removes the stale PID file that a crashed driver container can leave behind.
- It unloads nouveau if present, since the installer relies on driver-manager for this.
- It restarts the DRA kubelet-plugin. I found that a plugin that ran against a previous driver container keeps its bind mount pinned to that rootfs and fails new `NodePrepareResources` calls against the replacement.
- It restores any `gpu.deploy.*` labels that a previous failed attempt left paused, then returns.

## Testing

I tested on a live single-GPU (Tesla T4) kubeadm cluster running the DRA stack, with a GPU workload pod holding an allocated ResourceClaim.

- I reproduced the deadlock with the base branch. After a reboot, the dra-validator was stuck in `Terminating`, the workload looped `FailedPrepareDynamicResources: DRA driver gpu.nvidia.com is not registered`, and the node stayed driver-less for 11 hours.
- I deployed this fix onto the deadlocked node and it recovered in about 5 minutes with no manual cleanup.
- I replaced the driver pod on a live node to confirm the kubelet-plugin restart is required. Without it, new claim prepares fail with `empty device edits`. With it, a fresh claim pod ran `nvidia-smi` about 20 seconds after the rotation.
- I rebooted the node with the fix in place. It recovered hands-off in about 7 minutes with zero stuck pods, and the workload kept its claim and GPU across the reboot.
- I verified the existing paths are unchanged. With the driver loaded, the same build ran the normal eviction and reload flow.
