### PR TITLE
[Dockerfile] add pre-defined OCI labels

### DIFF
--- a/deployments/container/Dockerfile.distroless
+++ b/deployments/container/Dockerfile.distroless
@@ -68,6 +68,10 @@ RUN apt-get update \
 
 FROM nvcr.io/nvidia/distroless/cc:v4.0.8
 
+ARG VERSION="unknown"
+ARG GIT_COMMIT="unknown"
+ARG BUILD_TIMESTAMP
+
 USER 0:0
 
 COPY --from=shell /busybox /busybox
@@ -84,6 +88,15 @@ LABEL version="${VERSION}"
 LABEL release="N/A"
 LABEL summary="Manages upgrade of NVIDIA drivers on kubernetes"
 LABEL description="See summary"
+LABEL org.opencontainers.image.base.name="nvcr.io/nvidia/distroless/cc"
+LABEL org.opencontainers.image.created="${BUILD_TIMESTAMP}"
+LABEL org.opencontainers.image.documentation="https://docs.nvidia.com/datacenter/cloud-native/gpu-operator"
+LABEL org.opencontainers.image.revision="${GIT_COMMIT}"
+LABEL org.opencontainers.image.source="https://github.com/NVIDIA/k8s-driver-manager.git"
+LABEL org.opencontainers.image.title="NVIDIA Driver Manager For Kubernetes"
+LABEL org.opencontainers.image.url="https://catalog.ngc.nvidia.com/orgs/nvidia/cloud-native/containers/k8s-driver-manager"
+LABEL org.opencontainers.image.vendor="NVIDIA"
+LABEL org.opencontainers.image.version="${VERSION}"
 
 COPY LICENSE /licenses/
 

--- a/deployments/container/Makefile
+++ b/deployments/container/Makefile
@@ -64,6 +64,7 @@ $(BUILD_TARGETS): build-%:
 		--build-arg GIT_COMMIT="$(GIT_COMMIT)" \
 		--build-arg CVE_UPDATES="$(CVE_UPDATES)" \
 		--build-arg GOPROXY="$(GOPROXY)" \
+		--build-arg BUILD_TIMESTAMP="$(shell date -u +"%Y-%m-%dT%H:%M:%SZ")" \
 		--file $(DOCKERFILE) \
 		$(CURDIR)
 ifeq ($(PUSH_ON_BUILD),true)


### PR DESCRIPTION
**Before**
```
{
  "description": "See summary",
  "io.k8s.display-name": "NVIDIA Driver Upgrade Manager for Kubernetes",
  "name": "NVIDIA Driver Upgrade Manager for Kubernetes",
  "org.opencontainers.image.created": "2026-08-03T18:48:01Z",
  "org.opencontainers.image.documentation": "https://developer.download.nvidia.com/distroless-oss/docs.html",
  "org.opencontainers.image.revision": "e574cdfe875f68768c5690c8d9e88120bdfbdb51",
  "org.opencontainers.image.title": "C/C++ Distroless Image",
  "org.opencontainers.image.url": "https://developer.download.nvidia.com/distroless-oss/index.html",
  "org.opencontainers.image.version": "v4.0.9",
  "release": "N/A",
  "summary": "Manages upgrade of NVIDIA drivers on kubernetes",
  "vendor": "NVIDIA",
  "version": ""
}
```

**After**
```
{
  "description": "See summary",
  "io.k8s.display-name": "NVIDIA Driver Upgrade Manager for Kubernetes",
  "name": "NVIDIA Driver Upgrade Manager for Kubernetes",
  "org.opencontainers.base.name": "nvcr.io/nvidia/distroless/cc",
  "org.opencontainers.image.created": "2026-08-12T22:57:25Z",
  "org.opencontainers.image.documentation": "https://docs.nvidia.com/datacenter/cloud-native/gpu-operator",
  "org.opencontainers.image.revision": "57964f62a9c631ba3822d38ce2b7c6d0d86deb1a",
  "org.opencontainers.image.source": "https://github.com/NVIDIA/k8s-driver-manager.git",
  "org.opencontainers.image.title": "NVIDIA Driver Manager For Kubernetes",
  "org.opencontainers.image.url": "https://catalog.ngc.nvidia.com/orgs/nvidia/cloud-native/containers/k8s-driver-manager",
  "org.opencontainers.image.vendor": "NVIDIA",
  "org.opencontainers.image.version": "57964f62-arm64",
  "release": "N/A",
  "summary": "Manages upgrade of NVIDIA drivers on kubernetes",
  "vendor": "NVIDIA",
  "version": "57964f62-arm64"
}
```