### PR TITLE
vfio-manage: bind every PCI function of a GPU, not just the first auxiliary one

### DIFF
--- a/internal/nvpassthrough/nvpassthrough.go
+++ b/internal/nvpassthrough/nvpassthrough.go
@@ -34,6 +34,7 @@ const (
 	pciDriversRoot    = pciRootDir + "drivers"
 	vfioPCIDriverName = "vfio-pci"
 	consumerPrefix    = "consumer:pci:"
+	nvidiaVendorID    = "0x10de"
 	libModulesRoot    = "/lib/modules/"
 )
 
@@ -190,25 +191,25 @@ func (n *nvpassthrough) BindToVFIODriver(device *nvpci.NvidiaPCIDevice) error {
 		}
 	}
 
-	// For graphics mode, bind the auxiliary device as well
-	auxDev, err := getGraphicsAuxDev(device)
+	// Bind every other function of the same card. The whole IOMMU group must be bound to a
+	// vfio driver (or to nothing) before VFIO will hand it to a guest.
+	auxDevs, err := getAuxDevices(pciDevicesRoot, device)
 	if err != nil {
-		return fmt.Errorf("failed to get graphics auxiliary device for %s: %w", device.Address, err)
+		return fmt.Errorf("failed to get auxiliary devices for %s: %w", device.Address, err)
 	}
-	if auxDev == nil {
-		return nil
-	}
-	if auxDev.Driver == vfioDriverName {
-		return nil
-	}
+	for _, auxDev := range auxDevs {
+		if auxDev.Driver == vfioDriverName {
+			continue
+		}
 
-	n.logger.Infof("Binding graphics auxiliary device %s to driver: %s", auxDev.Address, vfioDriverName)
+		n.logger.Infof("Binding auxiliary device %s to driver: %s", auxDev.Address, vfioDriverName)
 
-	if err := unbind(auxDev.Address); err != nil {
-		return fmt.Errorf("failed to unbind graphics auxiliary device %s: %w", auxDev.Address, err)
-	}
-	if err := bind(auxDev.Address, vfioDriverName); err != nil {
-		return fmt.Errorf("failed to bind graphics auxiliary device %s to %s: %w", auxDev, vfioDriverName, err)
+		if err := unbind(auxDev.Address); err != nil {
+			return fmt.Errorf("failed to unbind auxiliary device %s: %w", auxDev.Address, err)
+		}
+		if err := bind(auxDev.Address, vfioDriverName); err != nil {
+			return fmt.Errorf("failed to bind auxiliary device %s to %s: %w", auxDev.Address, vfioDriverName, err)
+		}
 	}
 
 	return nil
@@ -222,14 +223,14 @@ func (n *nvpassthrough) UnbindFromDriver(device *nvpci.NvidiaPCIDevice) error {
 		return fmt.Errorf("failed to unbind device %s: %w", device.Address, err)
 	}
 
-	// For graphics mode, unbind the auxiliary device as well
-	auxDev, err := getGraphicsAuxDev(device)
+	// Unbind every other function of the same card, mirroring BindToVFIODriver.
+	auxDevs, err := getAuxDevices(pciDevicesRoot, device)
 	if err != nil {
-		return fmt.Errorf("failed to get graphics auxiliary device for %s: %w", device.Address, err)
+		return fmt.Errorf("failed to get auxiliary devices for %s: %w", device.Address, err)
 	}
-	if auxDev != nil {
+	for _, auxDev := range auxDevs {
 		if err := unbind(auxDev.Address); err != nil {
-			return fmt.Errorf("failed to unbind graphics auxiliary device %s: %w", auxDev.Address, err)
+			return fmt.Errorf("failed to unbind auxiliary device %s: %w", auxDev.Address, err)
 		}
 	}
 
@@ -275,51 +276,98 @@ func unbind(device string) error {
 	return nil
 }
 
-func getGraphicsAuxDev(device *nvpci.NvidiaPCIDevice) (*nvidiaPCIAuxDevice, error) {
-	if device.Class != nvpci.PCIVgaControllerClass {
+// getAuxDevices returns every other PCI function that belongs to the same physical card as
+// device.
+//
+// VFIO assigns an entire IOMMU group to a guest, and refuses the group unless every device in
+// it is bound to a vfio driver or to no driver at all. A discrete NVIDIA GPU is a
+// multi-function PCI device: .0 VGA/3D, .1 HDMI audio, and on Turing-era boards .2
+// (VirtualLink USB xHCI) and .3 (USB-C UCSI). If any of those is left bound to a host driver
+// such as xhci_hcd, the group is not viable and passthrough fails with
+// "vfio: group N is not viable".
+//
+// Functions are discovered two ways, and the results are unioned:
+//
+//   - Sibling PCI functions sharing the same domain:bus:device. This is the only way to find
+//     the VirtualLink xHCI and USB-C UCSI functions, which do not create a device link back
+//     to the GPU.
+//   - "consumer:pci:" device links, which the HDA audio function does create.
+//
+// Siblings are scoped to the physical card rather than to the IOMMU group on purpose: where
+// ACS is unavailable a group can span an entire root port, and unbinding unrelated devices
+// from their drivers would be harmful.
+func getAuxDevices(devicesRoot string, device *nvpci.NvidiaPCIDevice) ([]*nvidiaPCIAuxDevice, error) {
+	if !device.IsGPU() {
 		return nil, nil
 	}
 
-	// Look for consumer symlink
-	entries, err := os.ReadDir(device.Path)
-	if err != nil {
-		return nil, err
+	seen := map[string]bool{device.Address: true}
+	var auxDevs []*nvidiaPCIAuxDevice
+
+	add := func(address string) error {
+		if address == "" || seen[address] {
+			return nil
+		}
+		path := filepath.Join(devicesRoot, address)
+		if _, err := os.Stat(path); err != nil {
+			// The function is not present on this host; there is nothing to bind.
+			return nil
+		}
+		// Auxiliary functions of a GPU are by definition the same vendor. Checking guards
+		// against acting on a device we did not intend to touch.
+		vendor, err := os.ReadFile(filepath.Join(path, "vendor"))
+		if err != nil || strings.TrimSpace(string(vendor)) != nvidiaVendorID {
+			return nil
+		}
+		driver, err := getDriver(path)
+		if err != nil {
+			return fmt.Errorf("failed to get driver for auxiliary device %s: %w", address, err)
+		}
+		seen[address] = true
+		auxDevs = append(auxDevs, &nvidiaPCIAuxDevice{
+			Path:    path,
+			Address: address,
+			Driver:  driver,
+		})
+		return nil
 	}
 
-	for _, entry := range entries {
-		if strings.HasPrefix(entry.Name(), "consumer") {
-			// Extract aux device name from consumer:pci:XXXX:XX:XX.X format
-			parts := strings.Split(entry.Name(), consumerPrefix)
-			if len(parts) != 2 {
+	// Sibling functions: same domain:bus:device, differing only in function number.
+	if idx := strings.LastIndex(device.Address, "."); idx != -1 {
+		slotPrefix := device.Address[:idx+1]
+		entries, err := os.ReadDir(devicesRoot)
+		if err != nil {
+			return nil, fmt.Errorf("failed to list PCI devices in %s: %w", devicesRoot, err)
+		}
+		for _, entry := range entries {
+			if !strings.HasPrefix(entry.Name(), slotPrefix) {
 				continue
 			}
-
-			address := parts[1]
-			if address == "" {
-				continue
+			if err := add(entry.Name()); err != nil {
+				return nil, err
 			}
-
-			// Check if aux device exists
-			path := filepath.Join(pciDevicesRoot, address)
-			if _, err := os.Stat(path); err != nil {
-				continue
-			}
-
-			auxDev := &nvidiaPCIAuxDevice{
-				Path:    path,
-				Address: address,
-			}
-
-			driver, err := getDriver(path)
-			if err != nil {
-				return nil, fmt.Errorf("failed to get driver for graphics auxiliary device %s: %w", address, err)
-			}
-			auxDev.Driver = driver
-			return auxDev, nil
 		}
 	}
 
-	return nil, nil
+	// Consumer device links, e.g. the HDA audio function.
+	entries, err := os.ReadDir(device.Path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list %s: %w", device.Path, err)
+	}
+	for _, entry := range entries {
+		if !strings.HasPrefix(entry.Name(), "consumer") {
+			continue
+		}
+		parts := strings.Split(entry.Name(), consumerPrefix)
+		if len(parts) != 2 {
+			continue
+		}
+		if err := add(parts[1]); err != nil {
+			return nil, err
+		}
+	}
+
+	return auxDevs, nil
 }
 
 func getDriver(devicePath string) (string, error) {

--- a/internal/nvpassthrough/nvpassthrough_test.go
+++ b/internal/nvpassthrough/nvpassthrough_test.go
@@ -1,0 +1,206 @@
+package nvpassthrough
+
+import (
+	"os"
+	"path/filepath"
+	"sort"
+	"testing"
+
+	"github.com/NVIDIA/go-nvlib/pkg/nvpci"
+	"github.com/stretchr/testify/require"
+)
+
+// pciFunc describes one PCI function to materialise in the fake sysfs tree.
+type pciFunc struct {
+	address string
+	vendor  string
+	driver  string // empty means unbound
+}
+
+// newFakePCITree builds a minimal /sys/bus/pci/devices layout and returns its path.
+func newFakePCITree(t *testing.T, funcs []pciFunc, consumerLinksOn string, consumers []string) string {
+	t.Helper()
+	root := t.TempDir()
+	devicesRoot := filepath.Join(root, "devices")
+	driversRoot := filepath.Join(root, "drivers")
+	require.NoError(t, os.MkdirAll(devicesRoot, 0755))
+	require.NoError(t, os.MkdirAll(driversRoot, 0755))
+
+	for _, f := range funcs {
+		devPath := filepath.Join(devicesRoot, f.address)
+		require.NoError(t, os.MkdirAll(devPath, 0755))
+		require.NoError(t, os.WriteFile(filepath.Join(devPath, "vendor"), []byte(f.vendor+"\n"), 0644))
+		if f.driver != "" {
+			drvPath := filepath.Join(driversRoot, f.driver)
+			require.NoError(t, os.MkdirAll(drvPath, 0755))
+			require.NoError(t, os.Symlink(drvPath, filepath.Join(devPath, "driver")))
+		}
+	}
+
+	// "consumer:pci:<addr>" entries live in the GPU's own sysfs directory.
+	for _, c := range consumers {
+		require.NoError(t, os.MkdirAll(
+			filepath.Join(devicesRoot, consumerLinksOn, consumerPrefix+c), 0755))
+	}
+	return devicesRoot
+}
+
+func addressesOf(devs []*nvidiaPCIAuxDevice) []string {
+	out := make([]string, 0, len(devs))
+	for _, d := range devs {
+		out = append(out, d.Address)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func TestGetAuxDevices(t *testing.T) {
+	const nvidia = "0x10de"
+
+	testCases := []struct {
+		description string
+		funcs       []pciFunc
+		consumers   []string
+		gpu         string
+		class       uint32 // defaults to PCIVgaControllerClass
+		expected    []string
+	}{
+		{
+			description: "turing board: audio, VirtualLink xHCI and USB-C UCSI are all returned",
+			// .2/.3 have no consumer link -- they are only reachable via sibling enumeration
+			funcs: []pciFunc{
+				{"0000:16:00.0", nvidia, "vfio-pci"},
+				{"0000:16:00.1", nvidia, "vfio-pci"},
+				{"0000:16:00.2", nvidia, "xhci_hcd"},
+				{"0000:16:00.3", nvidia, ""},
+			},
+			consumers: []string{"0000:16:00.1"},
+			gpu:       "0000:16:00.0",
+			expected:  []string{"0000:16:00.1", "0000:16:00.2", "0000:16:00.3"},
+		},
+		{
+			description: "single-function GPU has no auxiliary devices",
+			funcs:       []pciFunc{{"0000:9b:00.0", nvidia, "vfio-pci"}},
+			gpu:         "0000:9b:00.0",
+			expected:    []string{},
+		},
+		{
+			description: "a sibling function from another vendor is not touched",
+			funcs: []pciFunc{
+				{"0000:16:00.0", nvidia, "vfio-pci"},
+				{"0000:16:00.1", "0x8086", "snd_hda_intel"},
+			},
+			gpu:      "0000:16:00.0",
+			expected: []string{},
+		},
+		{
+			description: "functions on a different slot are not siblings",
+			funcs: []pciFunc{
+				{"0000:16:00.0", nvidia, "vfio-pci"},
+				{"0000:17:00.0", nvidia, "vfio-pci"},
+			},
+			gpu:      "0000:16:00.0",
+			expected: []string{},
+		},
+		{
+			description: "GPU with a single HDA audio function is still returned",
+			funcs: []pciFunc{
+				{"0000:16:00.0", nvidia, "vfio-pci"},
+				{"0000:16:00.1", nvidia, "snd_hda_intel"},
+			},
+			consumers: []string{"0000:16:00.1"},
+			gpu:       "0000:16:00.0",
+			expected:  []string{"0000:16:00.1"},
+		},
+		{
+			description: "auxiliary device reachable only via a consumer link is still found",
+			funcs: []pciFunc{
+				{"0000:16:00.0", nvidia, "vfio-pci"},
+				{"0000:20:00.0", nvidia, "snd_hda_intel"},
+			},
+			consumers: []string{"0000:20:00.0"},
+			gpu:       "0000:16:00.0",
+			expected:  []string{"0000:20:00.0"},
+		},
+		{
+			description: "3D-controller-class GPU has its auxiliary functions returned",
+			funcs: []pciFunc{
+				{"0000:16:00.0", nvidia, "vfio-pci"},
+				{"0000:16:00.1", nvidia, "snd_hda_intel"},
+			},
+			gpu:      "0000:16:00.0",
+			class:    nvpci.PCI3dControllerClass,
+			expected: []string{"0000:16:00.1"},
+		},
+		{
+			description: "NVSwitch has no auxiliary functions handled",
+			funcs: []pciFunc{
+				{"0000:16:00.0", nvidia, "vfio-pci"},
+				{"0000:16:00.1", nvidia, "snd_hda_intel"},
+			},
+			gpu:      "0000:16:00.0",
+			class:    nvpci.PCINvSwitchClass,
+			expected: []string{},
+		},
+		{
+			description: "a function found both as a sibling and via a consumer link appears once",
+			funcs: []pciFunc{
+				{"0000:16:00.0", nvidia, "vfio-pci"},
+				{"0000:16:00.1", nvidia, "snd_hda_intel"},
+			},
+			consumers: []string{"0000:16:00.1"},
+			gpu:       "0000:16:00.0",
+			expected:  []string{"0000:16:00.1"},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			devicesRoot := newFakePCITree(t, tc.funcs, tc.gpu, tc.consumers)
+			class := tc.class
+			if class == 0 {
+				class = nvpci.PCIVgaControllerClass
+			}
+			dev := &nvpci.NvidiaPCIDevice{
+				Address: tc.gpu,
+				Path:    filepath.Join(devicesRoot, tc.gpu),
+				Class:   class,
+			}
+
+			auxDevs, err := getAuxDevices(devicesRoot, dev)
+			require.NoError(t, err)
+			require.ElementsMatch(t, tc.expected, addressesOf(auxDevs))
+		})
+	}
+}
+
+// The driver currently bound to each auxiliary function must be reported, since
+// BindToVFIODriver skips functions already on vfio-pci and unbinds the rest.
+func TestGetAuxDevicesReportsCurrentDriver(t *testing.T) {
+	const nvidia = "0x10de"
+	funcs := []pciFunc{
+		{"0000:16:00.0", nvidia, "vfio-pci"},
+		{"0000:16:00.1", nvidia, "vfio-pci"},
+		{"0000:16:00.2", nvidia, "xhci_hcd"},
+		{"0000:16:00.3", nvidia, ""},
+	}
+	devicesRoot := newFakePCITree(t, funcs, "0000:16:00.0", nil)
+	dev := &nvpci.NvidiaPCIDevice{
+		Address: "0000:16:00.0",
+		Path:    filepath.Join(devicesRoot, "0000:16:00.0"),
+		Class:   nvpci.PCIVgaControllerClass,
+	}
+
+	auxDevs, err := getAuxDevices(devicesRoot, dev)
+	require.NoError(t, err)
+
+	got := map[string]string{}
+	for _, d := range auxDevs {
+		got[d.Address] = d.Driver
+	}
+	require.Equal(t, map[string]string{
+		"0000:16:00.1": "vfio-pci",
+		"0000:16:00.2": "xhci_hcd",
+		"0000:16:00.3": "",
+	}, got)
+}


### PR DESCRIPTION
## Problem

On a host with a multi-function NVIDIA GPU, `vfio-manage bind` can leave the IOMMU group in a
state VFIO will not accept, and starting a VM then fails with:

```
vfio: group 15 is not viable
```

VFIO assigns an entire IOMMU group to a guest and refuses the group unless *every* device in it
is bound to a vfio driver or to no driver at all. A discrete NVIDIA GPU is a multi-function PCI
device:

| Function | Class    | Device                    |
|----------|----------|---------------------------|
| `.0`     | 0x030000 / 0x030200 | VGA / 3D controller |
| `.1`     | 0x040300 | HDA audio                 |
| `.2`     | 0x0c0330 | VirtualLink USB xHCI (Turing-era boards) |
| `.3`     | 0x0c8000 | USB-C UCSI (Turing-era boards) |

After `bind --all`, `.2` is typically still owned by `xhci_hcd`:

```
0000:16:00.0 -> vfio-pci
0000:16:00.1 -> vfio-pci
0000:16:00.2 -> xhci_hcd     <-- group is not viable
0000:16:00.3 -> UNBOUND
```

An *unbound* function is fine; a function owned by a host driver is not.

## Root cause

`getGraphicsAuxDev()` has three limitations that compound:

1. **It returns on the first match.** The `return auxDev, nil` is inside the loop, so at most one
   auxiliary function is ever bound.
2. **It discovers functions only via `consumer:pci:` device links.** The HDA audio function
   creates one; the VirtualLink xHCI and USB-C UCSI functions do not, so they are structurally
   invisible to this code no matter how many matches it collected.
3. **It returns early unless the device is `PCIVgaControllerClass`.** A GPU enumerating as a 3D
   controller (`0x030200`) gets no auxiliary handling at all.

## Fix

Replace it with `getAuxDevices()`, which returns every other PCI function belonging to the same
physical card. Functions are discovered two ways and the results unioned and de-duplicated:

- **sibling functions** sharing a `domain:bus:device` — the only way to reach the VirtualLink
  xHCI and USB-C UCSI functions;
- **`consumer:pci:` device links** — preserving the existing discovery path.

`BindToVFIODriver()` and `UnbindFromDriver()` now iterate over all of them.

Two deliberate constraints:

- **Siblings are scoped to the physical card, not to the IOMMU group.** Where ACS is unavailable
  a group can span an entire root port, and unrelated devices must not be unbound from their
  drivers.
- **A vendor check** guards against acting on anything that is not an NVIDIA function.

## Behaviour preserved

- Devices are still gated on `IsGPU()`, so **NVSwitches are unchanged** — they get no auxiliary
  handling, exactly as before. `IsGPU()` covers both the VGA and 3D controller classes, which is
  what fixes (3) above.
- A GPU whose only auxiliary function is HDA audio behaves exactly as it did.
- Consumer links are still followed wherever they point, so discovery is never narrower than
  before.
- A single-function GPU returns an empty set and takes the same path as today.
- No change to `cmd/vfio-manage/` — CLI behaviour and exit codes are untouched.

## Testing

Nine table-driven cases added in `internal/nvpassthrough/nvpassthrough_test.go`, using a fake
sysfs tree built with `t.TempDir()`:

| Case | Covers |
|---|---|
| Turing board: audio + VirtualLink xHCI + USB-C UCSI all returned | the bug |
| GPU with a single HDA audio function is still returned | pre-existing behaviour |
| Auxiliary device reachable only via a consumer link is still found | discovery not narrowed |
| 3D-controller-class GPU has its auxiliary functions returned | defect (3) |
| NVSwitch has no auxiliary functions handled | behaviour preserved |
| Single-function GPU has no auxiliary devices | no spurious results |
| Sibling function from another vendor is not touched | vendor guard |
| Functions on a different slot are not siblings | card-scoped, not group-scoped |
| A function found both as a sibling and via a consumer link appears once | de-duplication |

Plus `TestGetAuxDevicesReportsCurrentDriver`, since `BindToVFIODriver` skips functions already on
`vfio-pci` and unbinds the rest.

Verified locally:

```
go build ./...   OK
go vet ./...     clean
gofmt            clean
go test ./...    ok
golangci-lint    0 issues
```

---

*This change was written with AI assistance (Claude) and reviewed by me.*
